### PR TITLE
Changed version of Node runtime, node 6 is deprecated on lambdas

### DIFF
--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -2,7 +2,7 @@ service: auth0-APIGateway-customAuthorizer
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   cfLogs: true
   timeout: 20
   stage: dev


### PR DESCRIPTION
Changed the node runtime on serverless.yml. Node 6 is not supported anymore on aws lambdas.